### PR TITLE
Unbornchikken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ netbeans
 node_modules
 *~
 headers
+
+# IDE
+.idea

--- a/lib/cl_1_0.js
+++ b/lib/cl_1_0.js
@@ -29,16 +29,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 var my = require("myclass"), bridjs = require("bridjs"), ClBase = require("./cl_base"),
-        Signature = bridjs.Signature, ImageDesc, BufferRegion, Utils = require("./utils"),
-        NodeCLException = require("./nodecl_exception"), Type = require("./cl_type"),
-        log4js = require("log4js"),
-        log = log4js.getLogger("Cl10");
-
+    Signature = bridjs.Signature, ImageDesc, BufferRegion, Utils = require("./utils"),
+    NodeCLException = require("./nodecl_exception"), Type = require("./cl_type"),
+    log4js = require("log4js"),
+    log = log4js.getLogger("Cl10");
 
 
 module.exports = my.Class({
     STATIC: {
-        getVersion: function() {
+        getVersion: function () {
             return 1.0;
         }
     },
@@ -81,8 +80,8 @@ module.exports = my.Class({
 //                void *                  /* user_data */,
 //                cl_int *                /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createContext: bridjs.defineFunction(Signature.pointer, Signature.uint, Signature.pointer,
-            bridjs.byPointer(Type.createContextNotify),
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateContext"),
+        bridjs.byPointer(Type.createContextNotify),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateContext"),
 //extern CL_API_ENTRY cl_context CL_API_CALL
 //clCreateContextFromType(const cl_context_properties * /* properties */,
 //                        cl_device_type          /* device_type */,
@@ -90,8 +89,8 @@ module.exports = my.Class({
 //                        void *                  /* user_data */,
 //                        cl_int *                /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createContextFromType: bridjs.defineFunction(Signature.pointer, Signature.pointer, Type.deviceType,
-            bridjs.byPointer(Type.createContextNotify),
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateContextFromType"),
+        bridjs.byPointer(Type.createContextNotify),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateContextFromType"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainContext(cl_context /* context */) CL_API_SUFFIX__VERSION_1_0;
     retainContext: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainContext"),
@@ -105,8 +104,8 @@ module.exports = my.Class({
 //                 void *             /* param_value */, 
 //                 size_t *           /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getContextInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.contextInfo,
-            Signature.size,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetContextInfo"),
+        Signature.size,
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetContextInfo"),
     /* Command Queue APIs */
 //extern CL_API_ENTRY cl_command_queue CL_API_CALL
 //clCreateCommandQueue(cl_context                     /* context */, 
@@ -114,7 +113,7 @@ module.exports = my.Class({
 //                     cl_command_queue_properties    /* properties */,
 //                     cl_int *                       /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createCommandQueue: bridjs.defineFunction(Signature.pointer, Signature.pointer, Type.deviceId,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateCommandQueue"),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateCommandQueue"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainCommandQueue(cl_command_queue /* command_queue */) CL_API_SUFFIX__VERSION_1_0;
     retainCommandQueue: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainCommandQueue"),
@@ -128,7 +127,7 @@ module.exports = my.Class({
 //                      void *                /* param_value */,
 //                      size_t *              /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getCommandQueueInfo: bridjs.defineFunction(Signature.int, Type.commandQueue, Type.commandQueueInfo, Signature.size,
-            Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clGetCommandQueueInfo"),
+        Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clGetCommandQueueInfo"),
     /* Memory Object APIs */
 //extern CL_API_ENTRY cl_mem CL_API_CALL
 //clCreateBuffer(cl_context   /* context */,
@@ -137,7 +136,7 @@ module.exports = my.Class({
 //               void *       /* host_ptr */,
 //               cl_int *     /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createBuffer: bridjs.defineFunction(Type.mem, Signature.pointer, Type.memFlags, Signature.size,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateBuffer"),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateBuffer"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainMemObject(cl_mem /* memobj */) CL_API_SUFFIX__VERSION_1_0;
     retainMemObject: bridjs.defineFunction(Signature.int, Type.mem).bind("clRetainMemObject"),
@@ -152,7 +151,7 @@ module.exports = my.Class({
 //                           cl_image_format *    /* image_formats */,
 //                           cl_uint *            /* num_image_formats */) CL_API_SUFFIX__VERSION_1_0;
     getSupportedImageFormats: bridjs.defineFunction(Signature.int, Type.context, Type.memFlags, Type.memObjectType, Signature.uint,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.uint)).bind("clGetSupportedImageFormats"),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.uint)).bind("clGetSupportedImageFormats"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clGetMemObjectInfo(cl_mem           /* memobj */,
 //                   cl_mem_info      /* param_name */, 
@@ -160,7 +159,7 @@ module.exports = my.Class({
 //                   void *           /* param_value */,
 //                   size_t *         /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getMemObjectInfo: bridjs.defineFunction(Signature.int, Type.mem, Type.memInfo, Signature.size,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetMemObjectInfo"),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetMemObjectInfo"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clGetImageInfo(cl_mem           /* image */,
 //               cl_image_info    /* param_name */, 
@@ -168,7 +167,7 @@ module.exports = my.Class({
 //               void *           /* param_value */,
 //               size_t *         /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getImageInfo: bridjs.defineFunction(Signature.int, Type.mem, Type.memInfo, Signature.size,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetImageInfo"),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetImageInfo"),
     /* Sampler APIs */
 //extern CL_API_ENTRY cl_sampler CL_API_CALL
 //clCreateSampler(cl_context          /* context */,
@@ -177,7 +176,7 @@ module.exports = my.Class({
 //                cl_filter_mode      /* filter_mode */,
 //                cl_int *            /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createSampler: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.bool, Type.addressingMode, Type.filterMode,
-            bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateSampler"),
+        bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateSampler"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainSampler(cl_sampler /* sampler */) CL_API_SUFFIX__VERSION_1_0;
     retainSampler: bridjs.defineFunction(Signature.int).bind("clRetainSampler"),
@@ -191,7 +190,7 @@ module.exports = my.Class({
 //                 void *             /* param_value */,
 //                 size_t *           /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getSamplerInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.samplerInfo, Signature.size, Signature.pointer,
-            bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetSamplerInfo"),
+        bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetSamplerInfo"),
     /* Program Object APIs  */
 //extern CL_API_ENTRY cl_program CL_API_CALL
 //clCreateProgramWithSource(cl_context        /* context */,
@@ -200,7 +199,7 @@ module.exports = my.Class({
 //                          const size_t *    /* lengths */,
 //                          cl_int *          /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createProgramWithSource: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.string),
-            bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithSource"),
+        bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithSource"),
 //extern CL_API_ENTRY cl_program CL_API_CALL
 //clCreateProgramWithBinary(cl_context                     /* context */,
 //                          cl_uint                        /* num_devices */,
@@ -210,7 +209,7 @@ module.exports = my.Class({
 //                          cl_int *                       /* binary_status */,
 //                          cl_int *                       /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createProgramWithBinary: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, Signature.pointer,
-            bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.int), bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBinary"),
+        bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.int), bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBinary"),
 //extern CL_API_ENTRY cl_program CL_API_CALL
 //clCreateProgramWithBuiltInKernels(cl_context            /* context */,
 //                                  cl_uint               /* num_devices */,
@@ -218,7 +217,7 @@ module.exports = my.Class({
 //                                  const char *          /* kernel_names */,
 //                                  cl_int *              /* errcode_ret */) CL_API_SUFFIX__VERSION_1_2;
     createProgramWithBuiltInKernels: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
-            Signature.string, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBuiltInKernels"),
+        Signature.string, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBuiltInKernels"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainProgram(cl_program /* program */) CL_API_SUFFIX__VERSION_1_0;
     retainProgram: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainProgram"),
@@ -233,15 +232,15 @@ module.exports = my.Class({
     //              void (CL_CALLBACK *  /* pfn_notify */)(cl_program /* program */, void * /* user_data */),
     //              void *               /* user_data */) CL_API_SUFFIX__VERSION_1_0;
     buildProgram: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
-            Signature.string, bridjs.byPointer(Type.buildProgramNotify), Signature.pointer).bind("clBuildProgram"),
+        Signature.string, bridjs.byPointer(Type.buildProgramNotify), Signature.pointer).bind("clBuildProgram"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clGetProgramInfo(cl_program         /* program */,
 //                 cl_program_info    /* param_name */,
 //                 size_t             /* param_value_size */,
 //                 void *             /* param_value */,
 //                 size_t *           /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
-    getProgramInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.programInfo, Signature.size,Signature.pointer,
-            bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetProgramInfo"),
+    getProgramInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.programInfo, Signature.size, Signature.pointer,
+        bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetProgramInfo"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clGetProgramBuildInfo(cl_program            /* program */,
 //                      cl_device_id          /* device */,
@@ -250,21 +249,21 @@ module.exports = my.Class({
 //                      void *                /* param_value */,
 //                      size_t *              /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getProgramBuildInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.deviceId, Type.programBuildInfo, Signature.size, Signature.pointer,
-            bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetProgramBuildInfo"),
+        bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetProgramBuildInfo"),
     /* Kernel Object APIs */
 //extern CL_API_ENTRY cl_kernel CL_API_CALL
 //clCreateKernel(cl_program      /* program */,
 //               const char *    /* kernel_name */,
 //               cl_int *        /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createKernel: bridjs.defineFunction(Signature.pointer, Signature.pointer,
-            Signature.string, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateKernel"),
+        Signature.string, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateKernel"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clCreateKernelsInProgram(cl_program     /* program */,
 //                         cl_uint        /* num_kernels */,
 //                         cl_kernel *    /* kernels */,
 //                         cl_uint *      /* num_kernels_ret */) CL_API_SUFFIX__VERSION_1_0;
     createKernelsInProgram: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint,
-            bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.uint)).bind("clCreateKernelsInProgram"),
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.uint)).bind("clCreateKernelsInProgram"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainKernel(cl_kernel    /* kernel */) CL_API_SUFFIX__VERSION_1_0;
     retainKernel: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainKernel"),
@@ -286,16 +285,7 @@ module.exports = my.Class({
 //                void *          /* param_value */,
 //                size_t *        /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getKernelInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.kernelInfo,
-            Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelInfo"),
-//extern CL_API_ENTRY cl_int CL_API_CALL
-//clGetKernelArgInfo(cl_kernel       /* kernel */,
-//                   cl_uint         /* arg_indx */,
-//                   cl_kernel_arg_info  /* param_name */,
-//                   size_t          /* param_value_size */,
-//                   void *          /* param_value */,
-//                   size_t *        /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_2;
-    getKernelArgInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint, Type.kernelArgInfo,
-            Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelArgInfo"),
+        Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelInfo"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clGetKernelWorkGroupInfo(cl_kernel                  /* kernel */,
 //                         cl_device_id               /* device */,
@@ -304,7 +294,7 @@ module.exports = my.Class({
 //                         void *                     /* param_value */,
 //                         size_t *                   /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getKernelWorkGroupInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.deviceId, Type.kernelWorkGroupInfo,
-            Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelWorkGroupInfo"),
+        Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelWorkGroupInfo"),
     /* Event Object APIs */
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clWaitForEvents(cl_uint             /* num_events */,
@@ -317,12 +307,12 @@ module.exports = my.Class({
 //               void *           /* param_value */,
 //               size_t *         /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getEventInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.eventInfo,
-            Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetEventInfo"),
+        Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetEventInfo"),
 //extern CL_API_ENTRY cl_event CL_API_CALL
 //clCreateUserEvent(cl_context    /* context */,
     //                 cl_int *      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;               
     createUserEvent: bridjs.defineFunction(Signature.pointer,
-            bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateUserEvent"),
+        bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateUserEvent"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainEvent(cl_event /* event */) CL_API_SUFFIX__VERSION_1_0;
     createRetainEvent: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainEvent"),
@@ -339,7 +329,7 @@ module.exports = my.Class({
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clReleaseEvent(cl_event /* event */) CL_API_SUFFIX__VERSION_1_0;
     getEventProfilingInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.profilingInfo, Signature.size,
-            Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetEventProfilingInfo"),
+        Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetEventProfilingInfo"),
     /* Flush and Finish APIs */
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clFlush(cl_command_queue /* command_queue */) CL_API_SUFFIX__VERSION_1_0;
@@ -359,7 +349,7 @@ module.exports = my.Class({
 //                    const cl_event *    /* event_wait_list */,
 //                    cl_event *          /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueReadBuffer: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.bool,
-            Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueReadBuffer"),
+        Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueReadBuffer"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueWriteBuffer(cl_command_queue   /* command_queue */, 
 //                     cl_mem             /* buffer */, 
@@ -371,7 +361,7 @@ module.exports = my.Class({
 //                     const cl_event *   /* event_wait_list */, 
 //                     cl_event *         /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueWriteBuffer: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.bool,
-            Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueWriteBuffer"),
+        Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueWriteBuffer"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueCopyBuffer(cl_command_queue    /* command_queue */, 
 //                    cl_mem              /* src_buffer */,
@@ -383,7 +373,7 @@ module.exports = my.Class({
 //                   const cl_event *    /* event_wait_list */,
 //                    cl_event *          /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueCopyBuffer: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Type.mem,
-            Signature.size, Signature.size, Signature.size, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyBuffer"),
+        Signature.size, Signature.size, Signature.size, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyBuffer"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueReadImage(cl_command_queue     /* command_queue */,
 //                   cl_mem               /* image */,
@@ -398,7 +388,7 @@ module.exports = my.Class({
 //                   cl_event *           /* event */) CL_API_SUFFIX__VERSION_1_0;
 
     enqueueReadImage: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.bool,
-            Signature.pointer, Signature.pointer, Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueReadImage"),
+        Signature.pointer, Signature.pointer, Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueReadImage"),
 //extern CL_API_ENTRY cl_int CL_API_CALL/
 //clEnqueueWriteImage(cl_command_queue    /* command_queue */,
 //                    cl_mem              /* image */,
@@ -412,7 +402,7 @@ module.exports = my.Class({
 //                   const cl_event *    /* event_wait_list */,
 //                    cl_event *          /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueWriteImage: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.bool,
-            Signature.pointer, Signature.pointer, Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueWriteImage"),
+        Signature.pointer, Signature.pointer, Signature.size, Signature.size, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueWriteImage"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueCopyImage(cl_command_queue     /* command_queue */,
 //                   cl_mem               /* src_image */,
@@ -425,7 +415,7 @@ module.exports = my.Class({
 //                   cl_event *           /* event */) CL_API_SUFFIX__VERSION_1_0;
 
     enqueueCopyImage: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Type.mem,
-            Signature.pointer, Signature.pointer, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyImage"),
+        Signature.pointer, Signature.pointer, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyImage"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueCopyImageToBuffer(cl_command_queue /* command_queue */,
 //                           cl_mem           /* src_image */,
@@ -437,7 +427,7 @@ module.exports = my.Class({
 //                           const cl_event * /* event_wait_list */,
 //                           cl_event *       /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueCopyImageToBuffer: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Type.mem,
-            Signature.pointer, Signature.pointer, Signature.size, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyImageToBuffer"),
+        Signature.pointer, Signature.pointer, Signature.size, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyImageToBuffer"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueCopyBufferToImage(cl_command_queue /* command_queue */,
 //                           cl_mem           /* src_buffer */,
@@ -449,7 +439,7 @@ module.exports = my.Class({
 //                           const cl_event * /* event_wait_list */,
 //                           cl_event *       /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueCopyBufferToImage: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Type.mem, Signature.size,
-            Signature.pointer, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyBufferToImage"),
+        Signature.pointer, Signature.pointer, Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueCopyBufferToImage"),
 //extern CL_API_ENTRY void * CL_API_CALL
 //clEnqueueMapBuffer(cl_command_queue /* command_queue */,
 //                   cl_mem           /* buffer */,
@@ -462,7 +452,7 @@ module.exports = my.Class({
 //                   cl_event *       /* event */,
 //                   cl_int *         /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     enqueueMapBuffer: bridjs.defineFunction(Signature.pointer, Signature.pointer, Type.mem, Signature.bool,
-            Type.mapFlags, Signature.size, Signature.size, Signature.uint, Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clEnqueueMapBuffer"),
+        Type.mapFlags, Signature.size, Signature.size, Signature.uint, Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clEnqueueMapBuffer"),
 //extern CL_API_ENTRY void * CL_API_CALL
 //clEnqueueMapImage(cl_command_queue  /* command_queue */,
 //                  cl_mem            /* image */, 
@@ -477,8 +467,8 @@ module.exports = my.Class({
 //                  cl_event *        /* event */,
 //                  cl_int *          /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     enqueueMapImage: bridjs.defineFunction(Signature.pointer, Signature.pointer, Type.mem, Signature.bool,
-            Type.mapFlags, bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size),
-            Signature.uint, Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clEnqueueMapImage"),
+        Type.mapFlags, bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size),
+        Signature.uint, Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clEnqueueMapImage"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueUnmapMemObject(cl_command_queue /* command_queue */,
 //                        cl_mem           /* memobj */,
@@ -487,7 +477,7 @@ module.exports = my.Class({
 //                        const cl_event *  /* event_wait_list */,
 //                        cl_event *        /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueUnmapMemObject: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.pointer,
-            Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueUnmapMemObject"),
+        Signature.uint, Signature.pointer, Signature.pointer).bind("clEnqueueUnmapMemObject"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueNDRangeKernel(cl_command_queue /* command_queue */,
 //                       cl_kernel        /* kernel */,
@@ -499,9 +489,9 @@ module.exports = my.Class({
 //                       const cl_event * /* event_wait_list */,
 //                       cl_event *       /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueNDRangeKernel: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.pointer,
-            Signature.uint, bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size),
-            Signature.uint,
-            Signature.pointer, Signature.pointer).bind("clEnqueueNDRangeKernel"),
+        Signature.uint, bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size),
+        Signature.uint,
+        Signature.pointer, Signature.pointer).bind("clEnqueueNDRangeKernel"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueTask(cl_command_queue  /* command_queue */,
 //              cl_kernel         /* kernel */,
@@ -509,7 +499,7 @@ module.exports = my.Class({
 //              const cl_event *  /* event_wait_list */,
 //              cl_event *        /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueTask: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.pointer,
-            Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueTask"),
+        Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueTask"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueNativeKernel(cl_command_queue  /* command_queue */,
 //					  void (CL_CALLBACK * /*user_func*/)(void *), 
@@ -522,8 +512,8 @@ module.exports = my.Class({
 //                      const cl_event *  /* event_wait_list */,
 //                      cl_event *        /* event */) CL_API_SUFFIX__VERSION_1_0;
     enqueueNativeKernel: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.pointer, bridjs.byPointer(Type.enqueueNativeKernelUserFunc),
-            Signature.pointer, Signature.size, Signature.uint, Type.mem, bridjs.byPointer(bridjs.NativeValue.pointer), Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
-            bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueNativeKernel")
+        Signature.pointer, Signature.size, Signature.uint, Type.mem, bridjs.byPointer(bridjs.NativeValue.pointer), Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
+        bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueNativeKernel")
 });
 
 Utils.extend(module.exports, ClBase);

--- a/lib/cl_1_0.js
+++ b/lib/cl_1_0.js
@@ -210,14 +210,6 @@ module.exports = my.Class({
 //                          cl_int *                       /* errcode_ret */) CL_API_SUFFIX__VERSION_1_0;
     createProgramWithBinary: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, Signature.pointer,
         bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.int), bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBinary"),
-//extern CL_API_ENTRY cl_program CL_API_CALL
-//clCreateProgramWithBuiltInKernels(cl_context            /* context */,
-//                                  cl_uint               /* num_devices */,
-//                                  const cl_device_id *  /* device_list */,
-//                                  const char *          /* kernel_names */,
-//                                  cl_int *              /* errcode_ret */) CL_API_SUFFIX__VERSION_1_2;
-    createProgramWithBuiltInKernels: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
-        Signature.string, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBuiltInKernels"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainProgram(cl_program /* program */) CL_API_SUFFIX__VERSION_1_0;
     retainProgram: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainProgram"),
@@ -308,11 +300,6 @@ module.exports = my.Class({
 //               size_t *         /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_0;
     getEventInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Type.eventInfo,
         Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetEventInfo"),
-//extern CL_API_ENTRY cl_event CL_API_CALL
-//clCreateUserEvent(cl_context    /* context */,
-    //                 cl_int *      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;               
-    createUserEvent: bridjs.defineFunction(Signature.pointer,
-        bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateUserEvent"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainEvent(cl_event /* event */) CL_API_SUFFIX__VERSION_1_0;
     createRetainEvent: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainEvent"),

--- a/lib/cl_1_1.js
+++ b/lib/cl_1_1.js
@@ -123,7 +123,12 @@ lib = my.Class(cl10, {
 
     enqueueCopyBufferRect: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Type.mem,
         bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), Signature.size, Signature.size, Signature.size, Signature.size,
-        Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueCopyBufferRect")
+        Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueCopyBufferRect"),
+    //extern CL_API_ENTRY cl_event CL_API_CALL
+//clCreateUserEvent(cl_context    /* context */,
+    //                 cl_int *      /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;
+    createUserEvent: bridjs.defineFunction(Signature.pointer,
+        bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateUserEvent")
 });
 
 Utils.extend(lib, cl10);

--- a/lib/cl_1_1.js
+++ b/lib/cl_1_1.js
@@ -28,14 +28,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var my = require("myclass"), bridjs = require("bridjs"),Utils = require("./utils"),
-        Signature = bridjs.Signature, ImageDesc, BufferRegion,
-        NodeCLException = require("./nodecl_exception"), Type = require("./cl_type"),
-        cl10 = require("./cl_1_0"), lib;
+var my = require("myclass"), bridjs = require("bridjs"), Utils = require("./utils"),
+    Signature = bridjs.Signature, ImageDesc, BufferRegion,
+    NodeCLException = require("./nodecl_exception"), Type = require("./cl_type"),
+    cl10 = require("./cl_1_0"), lib;
 
-lib = my.Class(cl10,{
-    STATIC:{
-        getVersion:function(){
+lib = my.Class(cl10, {
+    STATIC: {
+        getVersion: function () {
             return 1.1;
         }
     },
@@ -45,16 +45,16 @@ lib = my.Class(cl10,{
 //                  cl_buffer_create_type    /* buffer_create_type */,
 //                  const void *             /* buffer_create_info */,
 //                  cl_int *                 /* errcode_ret */) CL_API_SUFFIX__VERSION_1_1;
-createSubBuffer:bridjs.defineFunction(Type.mem,Type.mem,Signature.pointer,Type.memFlags, Type.bufferCreateType, 
-Signature.pointer, Signature.pointer,bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateSubBuffer"),
+    createSubBuffer: bridjs.defineFunction(Type.mem, Type.mem, Signature.pointer, Type.memFlags, Type.bufferCreateType,
+        Signature.pointer, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateSubBuffer"),
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clSetMemObjectDestructorCallback(  cl_mem /* memobj */, 
 //                                    void (CL_CALLBACK * /*pfn_notify*/)( cl_mem /* memobj */, void* /*user_data*/), 
 //                                    void * /*user_data */ )             CL_API_SUFFIX__VERSION_1_1;  
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clSetUserEventStatus(cl_event   /* event */,
- //                    cl_int     /* execution_status */) CL_API_SUFFIX__VERSION_1_1;
-setUserEventStatus:bridjs.defineFunction(Signature.int,Signature.pointer, Signature.int).bind("clSetUserEventStatus"),
+    //                    cl_int     /* execution_status */) CL_API_SUFFIX__VERSION_1_1;
+    setUserEventStatus: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.int).bind("clSetUserEventStatus"),
 
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clSetEventCallback( cl_event    /* event */,
@@ -62,8 +62,8 @@ setUserEventStatus:bridjs.defineFunction(Signature.int,Signature.pointer, Signat
 //                    void (CL_CALLBACK * /* pfn_notify */)(cl_event, cl_int, void *),
 //                    void *      /* user_data */) CL_API_SUFFIX__VERSION_1_1;
 
-setEventCallback:bridjs.defineFunction(Signature.int,Signature.pointer,Signature.int,bridjs.byPointer(Type.setEventCallbackCallback),
-Signature.pointer).bind("clSetEventCallback"),
+    setEventCallback: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.int, bridjs.byPointer(Type.setEventCallbackCallback),
+        Signature.pointer).bind("clSetEventCallback"),
 
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueReadBufferRect(cl_command_queue    /* command_queue */,
@@ -82,9 +82,9 @@ Signature.pointer).bind("clSetEventCallback"),
 //                        cl_event *          /* event */) CL_API_SUFFIX__VERSION_1_1;
 
     enqueueReadBufferRect: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.bool,
-            bridjs.byPointer(bridjs.NativeValue.size),bridjs.byPointer(bridjs.NativeValue.size),bridjs.byPointer(bridjs.NativeValue.size), Signature.size,Signature.size,Signature.size,Signature.size,
-            Signature.pointer, Signature.uint,  bridjs.byPointer(bridjs.NativeValue.pointer),  bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueReadBufferRect"),    
-    
+        bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), Signature.size, Signature.size, Signature.size, Signature.size,
+        Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueReadBufferRect"),
+
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueWriteBufferRect(cl_command_queue    /* command_queue */,
 //                         cl_mem              /* buffer */,
@@ -102,10 +102,10 @@ Signature.pointer).bind("clSetEventCallback"),
 //                         cl_event *          /* event */) CL_API_SUFFIX__VERSION_1_1;
 
     enqueueWriteBufferRect: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.bool,
-            bridjs.byPointer(bridjs.NativeValue.size),bridjs.byPointer(bridjs.NativeValue.size),bridjs.byPointer(bridjs.NativeValue.size), Signature.size,Signature.size,Signature.size,Signature.size,
-            Signature.pointer, Signature.uint,  bridjs.byPointer(bridjs.NativeValue.pointer),  bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueWriteBufferRect"),    
-    
-    
+        bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), Signature.size, Signature.size, Signature.size, Signature.size,
+        Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueWriteBufferRect"),
+
+
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueCopyBufferRect(cl_command_queue    /* command_queue */, 
 //                        cl_mem              /* src_buffer */,
@@ -121,9 +121,9 @@ Signature.pointer).bind("clSetEventCallback"),
 //                        const cl_event *    /* event_wait_list */,
 //                        cl_event *          /* event */) CL_API_SUFFIX__VERSION_1_1;  
 
-    enqueueCopyBufferRect: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem,Type.mem,
-            bridjs.byPointer(bridjs.NativeValue.size),bridjs.byPointer(bridjs.NativeValue.size),bridjs.byPointer(bridjs.NativeValue.size), Signature.size,Signature.size,Signature.size,Signature.size,
-             Signature.uint,  bridjs.byPointer(bridjs.NativeValue.pointer),  bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueCopyBufferRect"),       
+    enqueueCopyBufferRect: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Type.mem,
+        bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), bridjs.byPointer(bridjs.NativeValue.size), Signature.size, Signature.size, Signature.size, Signature.size,
+        Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueCopyBufferRect")
 });
 
 Utils.extend(lib, cl10);

--- a/lib/cl_1_2.js
+++ b/lib/cl_1_2.js
@@ -28,13 +28,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-var my = require("myclass"), bridjs = require("bridjs"),Utils = require("./utils"),
-        Signature = bridjs.Signature, ImageDesc, BufferRegion,
-        NodeCLException = require("./nodecl_exception"), Type = require("./cl_type"),
-        cl11 = require("./cl_1_1"), lib;
+var my = require("myclass"), bridjs = require("bridjs"), Utils = require("./utils"),
+    Signature = bridjs.Signature, ImageDesc, BufferRegion,
+    NodeCLException = require("./nodecl_exception"), Type = require("./cl_type"),
+    cl11 = require("./cl_1_1"), lib;
 lib = my.Class({
-    STATIC:{
-        getVersion:function(){
+    STATIC: {
+        getVersion: function () {
             return 1.2;
         }
     },
@@ -44,17 +44,17 @@ lib = my.Class({
 //                   cl_uint                              /* num_devices */,
 //                 cl_device_id *                       /* out_devices */,
 //                   cl_uint *                            /* num_devices_ret */) CL_API_SUFFIX__VERSION_1_2;
-createSubDevices:bridjs.defineFunction(Signature.int,Signature.pointer,bridjs.byPointer(bridjs.NativeValue.pointer),Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
-bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateSubDevices"),
+    createSubDevices: bridjs.defineFunction(Signature.int, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.pointer), Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
+        bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateSubDevices"),
 
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clRetainDevice(cl_device_id /* device */) CL_API_SUFFIX__VERSION_1_2;
-retainDevice:bridjs.defineFunction(Signature.int,Signature.pointer).bind("clRetainDevice"),
+    retainDevice: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clRetainDevice"),
 
 
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clReleaseDevice(cl_device_id /* device */) CL_API_SUFFIX__VERSION_1_2; 
-releaseDevice:bridjs.defineFunction(Signature.int,Signature.pointer).bind("clReleaseDevice"),
+    releaseDevice: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clReleaseDevice"),
 
 //extern CL_API_ENTRY cl_mem CL_API_CALL
 //clCreateImage(cl_context              /* context */,
@@ -63,10 +63,10 @@ releaseDevice:bridjs.defineFunction(Signature.int,Signature.pointer).bind("clRel
 //              const cl_image_desc *   /* image_desc */, 
 //              void *                  /* host_ptr */,
 //              cl_int *                /* errcode_ret */) CL_API_SUFFIX__VERSION_1_2;
-              
-createImage:bridjs.defineFunction(Type.mem,Signature.pointer,Type.memFlags,bridjs.byPointer(Type.ImageFormat), bridjs.byPointer(Type.ImageDesc),Signature.pointer,
-bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateImage"),              
-              
+
+    createImage: bridjs.defineFunction(Type.mem, Signature.pointer, Type.memFlags, bridjs.byPointer(Type.ImageFormat), bridjs.byPointer(Type.ImageDesc), Signature.pointer,
+        bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateImage"),
+
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clCompileProgram(cl_program           /* program */,
 //                 cl_uint              /* num_devices */,
@@ -77,10 +77,10 @@ bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateImage"),
 //                 const char **        /* header_include_names */,
 //                 void (CL_CALLBACK *  /* pfn_notify */)(cl_program /* program */, void * /* user_data */),
 //                 void *               /* user_data */) CL_API_SUFFIX__VERSION_1_2;
-                 
-compileProgram:bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint,bridjs.byPointer(bridjs.NativeValue.pointer), Signature.string, Signature.uint,
-    bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.string),bridjs.byPointer(Type.buildProgramNotify), Signature.pointer).bind("clCompileProgram"),                 
-                 
+
+    compileProgram: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), Signature.string, Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.string), bridjs.byPointer(Type.buildProgramNotify), Signature.pointer).bind("clCompileProgram"),
+
 //extern CL_API_ENTRY cl_program CL_API_CALL/
 //clLinkProgram(cl_context           /* context */,
 //              cl_uint              /* num_devices */,
@@ -92,12 +92,12 @@ compileProgram:bridjs.defineFunction(Signature.int, Signature.pointer, Signature
 //              void *               /* user_data */,
 //              cl_int *             /* errcode_ret */ ) CL_API_SUFFIX__VERSION_1_2;
 
-linkProgram:bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint,bridjs.byPointer(bridjs.NativeValue.pointer), Signature.string, Signature.uint,
-    bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(Type.buildProgramNotify,bridjs.byPointer(bridjs.NativeValue.int)), Signature.pointer).bind("clLinkProgram"),  
+    linkProgram: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), Signature.string, Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(Type.buildProgramNotify, bridjs.byPointer(bridjs.NativeValue.int)), Signature.pointer).bind("clLinkProgram"),
 
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clUnloadPlatformCompiler(cl_platform_id /* platform */) CL_API_SUFFIX__VERSION_1_2;
-unloadPlatformCompiler:bridjs.defineFunction(Signature.int, Signature.pointer).bind("clUnloadPlatformCompiler"),  
+    unloadPlatformCompiler: bridjs.defineFunction(Signature.int, Signature.pointer).bind("clUnloadPlatformCompiler"),
 
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueFillBuffer(cl_command_queue   /* command_queue */,
@@ -109,10 +109,10 @@ unloadPlatformCompiler:bridjs.defineFunction(Signature.int, Signature.pointer).b
 //                    cl_uint            /* num_events_in_wait_list */, 
 //                    const cl_event *   /* event_wait_list */, 
 //                    cl_event *         /* event */) CL_API_SUFFIX__VERSION_1_2;
-enqueueFillBuffer:bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.pointer, Signature.size, Signature.size,Signature.size, Signature.uint,
-    bridjs.byPointer(bridjs.NativeValue.pointer),bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueFillBuffer"),  
-    
-    
+    enqueueFillBuffer: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.pointer, Signature.size, Signature.size, Signature.size, Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueFillBuffer"),
+
+
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueFillImage(cl_command_queue   /* command_queue */,
 //                   cl_mem             /* image */, 
@@ -122,11 +122,11 @@ enqueueFillBuffer:bridjs.defineFunction(Signature.int, Signature.pointer, Type.m
 //                   cl_uint            /* num_events_in_wait_list */, 
 //                   const cl_event *   /* event_wait_list */, 
 //                   cl_event *         /* event */) CL_API_SUFFIX__VERSION_1_2;
- 
-enqueueFillImage:bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size), 
-    bridjs.byPointer(bridjs.NativeValue.size), Signature.uint,
-    bridjs.byPointer(bridjs.NativeValue.pointer),bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueFillImage"),     
-    
+
+    enqueueFillImage: bridjs.defineFunction(Signature.int, Signature.pointer, Type.mem, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size),
+        bridjs.byPointer(bridjs.NativeValue.size), Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueFillImage"),
+
 //                   extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueMigrateMemObjects(cl_command_queue       /* command_queue */,
 //                           cl_uint                /* num_mem_objects */,
@@ -135,36 +135,45 @@ enqueueFillImage:bridjs.defineFunction(Signature.int, Signature.pointer, Type.me
 //                           cl_uint                /* num_events_in_wait_list */,
 //                           const cl_event *       /* event_wait_list */,
 //                           cl_event *             /* event */) CL_API_SUFFIX__VERSION_1_2;
-enqueueMigrateMemObjects:bridjs.defineFunction(Signature.int, Signature.pointer,Signature.uint,bridjs.byPointer(bridjs.NativeValue.pointer), Type.memMigrationFlags, Signature.uint, 
-    bridjs.byPointer(bridjs.NativeValue.pointer),bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueMigrateMemObjects"),
-    
-    
+    enqueueMigrateMemObjects: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer), Type.memMigrationFlags, Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueMigrateMemObjects"),
+
+
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueMarkerWithWaitList(cl_command_queue /* command_queue */,
 //                            cl_uint           /* num_events_in_wait_list */,
 //                            const cl_event *  /* event_wait_list */,
 //                            cl_event *        /* event */) CL_API_SUFFIX__VERSION_1_2;
-enqueueMarkerWithWaitList:bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint,
-    bridjs.byPointer(bridjs.NativeValue.pointer),bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueMarkerWithWaitList"),
-    
+    enqueueMarkerWithWaitList: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueMarkerWithWaitList"),
+
 //extern CL_API_ENTRY cl_int CL_API_CALL
 //clEnqueueBarrierWithWaitList(cl_command_queue /* command_queue */,
 //                             cl_uint           /* num_events_in_wait_list */,
 //                             const cl_event *  /* event_wait_list */,
 //                             cl_event *        /* event */) CL_API_SUFFIX__VERSION_1_2;
-enqueueBarrierWithWaitList:bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint,
-    bridjs.byPointer(bridjs.NativeValue.pointer),bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueBarrierWithWaitList"),                             
- /* Extension function access
- *
- * Returns the extension function address for the given function name,
- * or NULL if a valid function can not be found.  The client must
- * check to make sure the address is not NULL, before using or 
- * calling the returned function address.
- */
+    enqueueBarrierWithWaitList: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint,
+        bridjs.byPointer(bridjs.NativeValue.pointer), bridjs.byPointer(bridjs.NativeValue.pointer)).bind("clEnqueueBarrierWithWaitList"),
+    /* Extension function access
+     *
+     * Returns the extension function address for the given function name,
+     * or NULL if a valid function can not be found.  The client must
+     * check to make sure the address is not NULL, before using or
+     * calling the returned function address.
+     */
 //extern CL_API_ENTRY void * CL_API_CALL 
 //clGetExtensionFunctionAddressForPlatform(cl_platform_id /* platform */,
 //                                         const char *   /* func_name */) CL_API_SUFFIX__VERSION_1_2;                            
-getExtensionFunctionAddressForPlatfor:bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.string).bind("clGetExtensionFunctionAddressForPlatform")                         
+    getExtensionFunctionAddressForPlatfor: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.string).bind("clGetExtensionFunctionAddressForPlatform"),
+    //extern CL_API_ENTRY cl_int CL_API_CALL
+//clGetKernelArgInfo(cl_kernel       /* kernel */,
+//                   cl_uint         /* arg_indx */,
+//                   cl_kernel_arg_info  /* param_name */,
+//                   size_t          /* param_value_size */,
+//                   void *          /* param_value */,
+//                   size_t *        /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_2;
+    getKernelArgInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint, Type.kernelArgInfo,
+        Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelArgInfo")
 });
 
 Utils.extend(lib, cl11);

--- a/lib/cl_1_2.js
+++ b/lib/cl_1_2.js
@@ -173,7 +173,15 @@ lib = my.Class({
 //                   void *          /* param_value */,
 //                   size_t *        /* param_value_size_ret */) CL_API_SUFFIX__VERSION_1_2;
     getKernelArgInfo: bridjs.defineFunction(Signature.int, Signature.pointer, Signature.uint, Type.kernelArgInfo,
-        Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelArgInfo")
+        Signature.size, Signature.pointer, bridjs.byPointer(bridjs.NativeValue.size)).bind("clGetKernelArgInfo"),
+    //extern CL_API_ENTRY cl_program CL_API_CALL
+//clCreateProgramWithBuiltInKernels(cl_context            /* context */,
+//                                  cl_uint               /* num_devices */,
+//                                  const cl_device_id *  /* device_list */,
+//                                  const char *          /* kernel_names */,
+//                                  cl_int *              /* errcode_ret */) CL_API_SUFFIX__VERSION_1_2;
+    createProgramWithBuiltInKernels: bridjs.defineFunction(Signature.pointer, Signature.pointer, Signature.uint, bridjs.byPointer(bridjs.NativeValue.pointer),
+        Signature.string, bridjs.byPointer(bridjs.NativeValue.int)).bind("clCreateProgramWithBuiltInKernels")
 });
 
 Utils.extend(lib, cl11);

--- a/lib/cl_type.js
+++ b/lib/cl_type.js
@@ -84,7 +84,7 @@ module.exports = my.Class(Signature, {
         memObjectType: Signature.uint,//typedef cl_uint             cl_mem_object_type;
         memInfo:  Signature.uint,//typedef cl_uint             cl_mem_object_type;
         memMigrationFlags: Signature.uint64,//typedef cl_bitfield         cl_mem_migration_flags;
-        imagInfo: Signature.uint, //typedef cl_uint             cl_image_info;
+        imageInfo: Signature.uint, //typedef cl_uint             cl_image_info;
         bufferCreateType:Signature.uint, //typedef cl_uint             cl_buffer_create_type;
         addressingMode: Signature.uint, //typedef cl_uint             cl_addressing_mode;
         filterMode: Signature.uint,// typedef cl_uint             cl_filter_mode;

--- a/lib/cl_type.js
+++ b/lib/cl_type.js
@@ -62,7 +62,8 @@ module.exports = my.Class(Signature, {
         ImageFormat: ImageFormat,
         ImageDesc: ImageDesc,
         BufferRegion: BufferRegion,
-        bool: Signature.bool,                     /* WARNING!  Unlike cl_ types in cl_platform.h, cl_bool is not guaranteed to be the same size as the bool in kernels. */ 
+        bool: Signature.bool,                     /* WARNING!  Unlike cl_ types in cl_platform.h, cl_bool is not guaranteed to be the same size as the bool in kernels. */
+        errcode: Signature.int, // cl_errcode
         bitfield: Signature.uint64, //typedef cl_ulong            cl_bitfield;
         deviceType: Signature.uint64,//typedef cl_bitfield         cl_device_type;
         platformInfo: Signature.uint,//typedef cl_uint             cl_platform_info;

--- a/lib/nodecl.js
+++ b/lib/nodecl.js
@@ -261,7 +261,7 @@ module.exports = my.Class({
                 }
             }
             lib = libraries[selectIndex];
-            bridjs.register(lib, "OpenCL");
+            bridjs.register(lib, /^win/.test(process.platform) ? "OpenCL" : "libOpenCL.so");
             log.info("Load OpenCL library: " + lib.getVersion());
 
             return new lib();


### PR DESCRIPTION
Hi,

There were OCL 1.1 and OCL 1.2 method definitions in the cl_1_1.js file and because of that the stuff is not worked in OCL 1.1 platforms (like my NVidia card).

Fixed.

BR,
chikk
